### PR TITLE
Apache config is broken when deploying roundup app.

### DIFF
--- a/overlay/etc/roundup/apache.conf
+++ b/overlay/etc/roundup/apache.conf
@@ -13,7 +13,6 @@ AliasMatch ^/(?!@@file/)(.*) /var/lib/roundup/tracker/dummy.py/$1
 
 <VirtualHost *:443>
     SSLEngine on
-    SSLCertificateFile /etc/ssl/certs/cert.pem
     ServerAdmin  webmaster@localhost
 </VirtualHost>
 


### PR DESCRIPTION
This causes apache2 not to start.

I'm pretty sure it is just an oversight by having the SSL Certificate still specified in the site configuration.

Thanks.
