### PR TITLE
Update for 15.0 update

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+turnkey-roundup-15.0 (1) turnkey; urgency=low
+
+  * Updated roundup to 1.5.1
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Stefan Davis <stefan@turnkeylinux.org>  Sun, 17 Dec 2017 23:44:02 +1100
+
 turnkey-roundup-14.2 (1) turnkey; urgency=low
 
   * Installed security updates.

--- a/conf.d/main
+++ b/conf.d/main
@@ -8,25 +8,41 @@ RT_TRACKER=/var/lib/roundup/tracker
 RT_TEMPLATE=classic
 RT_BACKEND=mysql
 
+pip install 'roundup==1.5.1'
+# workaround rowsize issue for mariadb 10.1
+patch /usr/local/lib/python2.7/dist-packages/roundup/backends/back_mysql.pt /usr/local/src/back_mysql.patch
+
 # convenience symlinks
 ln -s $RT_TRACKER /var/www/webroot
 ln -s /etc/roundup /var/www/config
 ln -s /usr/share/doc/roundup /var/www/docs
 
 # innodb workaround (Incorrect information in file: './roundup/schema.frm'")
-/etc/init.d/mysql start
-/etc/init.d/mysql stop
+service mysql start
+service mysql stop
 rm /var/lib/mysql/ib*
 
+# update MariaDB defaults to work around MariaDB10.1 bug
+MYCNF=/etc/mysql/mariadb.conf.d/99-turnkey-redmine-workaround.cnf
+cat > $MYCNF <<EOF
+[mysqld]
+default_tmp_storage_engine = InnoDB
+innodb_file_format = Barracuda
+innodb_file_format_max = Barracuda
+innodb_large_prefix = 1
+EOF
+
+a2enmod python
+
 # start mysql server
-/etc/init.d/mysql start
+service mysql start
 
 # create roundup and user and grant privs to yet to be created db
 mysql --user=root --password=$MYSQL_PASS --batch --execute "\
 GRANT ALL PRIVILEGES ON $NAME.* TO $NAME@localhost IDENTIFIED BY '$DB_PASS'; \
 FLUSH PRIVILEGES;"
 
-# roundup tracker creation
+mkdir -p $RT_TRACKER
 OPTIONS="admin_email=admin,dispatcher_email=admin,tracker_web=/,mail_domain=example.com,mail_host=localhost,rdbms_password=$DB_PASS"
 roundup-admin -i $RT_TRACKER install $RT_TEMPLATE $RT_BACKEND $OPTIONS
 roundup-admin -i $RT_TRACKER initialise $ADMIN_PASS
@@ -55,13 +71,9 @@ a2dissite 000-default
 a2ensite roundup
 rm -rf /var/www/html
 
-# we don't need roundup-server (using apache)
-update-rc.d -f roundup remove
-chmod -x /etc/init.d/roundup
-
 # remove empty folder created for multiple instances
 rm -rf /var/lib/roundup/trackers
 
 # stop mysql server
-/etc/init.d/mysql stop
+service mysql stop
 

--- a/overlay/usr/local/src/back_mysql.patch
+++ b/overlay/usr/local/src/back_mysql.patch
@@ -1,0 +1,36 @@
+176c176
+<             self.sql("CREATE TABLE `schema` (`schema` TEXT) ENGINE=%s"%
+---
+>             self.sql("CREATE TABLE `schema` (`schema` TEXT) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci"%
+179c179
+<                 num INTEGER) ENGINE=%s'''%self.mysql_backend)
+---
+>                 num INTEGER) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%self.mysql_backend)
+204c204
+<             ENGINE=%s'''%self.mysql_backend)
+---
+>             ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%self.mysql_backend)
+210c210
+<             ENGINE=%s'''%self.mysql_backend)
+---
+>             ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%self.mysql_backend)
+217c217
+<             ENGINE=%s'''%self.mysql_backend)
+---
+>             ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%self.mysql_backend)
+219c219
+<             _textid INT) ENGINE=%s'''%self.mysql_backend)
+---
+>             _textid INT) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%self.mysql_backend)
+402c402
+<         sql = 'create table _%s (%s) ENGINE=%s'%(spec.classname, scols,
+---
+>         sql = 'create table _%s (%s) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'%(spec.classname, scols,
+473c473
+<             action varchar(255), params text) ENGINE=%s'''%(
+---
+>             action varchar(255), params text) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%(
+487c487
+<             nodeid VARCHAR(255)) ENGINE=%s'''%(spec.classname, ml,
+---
+>             nodeid VARCHAR(255)) ENGINE=%s CHARACTER SET utf8 COLLATE utf8_general_ci'''%(spec.classname, ml,

--- a/plan/main
+++ b/plan/main
@@ -1,13 +1,19 @@
 #include <turnkey/base>
 
-apache2-mpm-worker
 libapache2-mod-python
 webmin-apache
+
+python-pip
+
+/* Dependencies of python-pip */
+python-setuptools
+python-wheel
+
+
+apache2
 
 mysql-server
 python-mysqldb
 webmin-mysql
-
-roundup
 
 python-tz               /* Full timezone support */


### PR DESCRIPTION
Included file `/usr/local/src/back_mysql.patch` is a patch for `/usr/local/lib/python2.7/roundup/backends/back_mysql.py` as a workaround for MariaDB 10.1 utf8mb/rowsize bug